### PR TITLE
Add DXT packaging support for Anthropic Extension Directoy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ out/
 *.bak
 *.orig
 *~
+
+# DXT archives
+*.dxt

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,59 @@
+{
+  "dxt_version": "0.1",
+  "name": "healthie-dev-assist",
+  "display_name": "Healthie Dev Assistant",
+  "version": "1.0.0",
+  "description": "Development assistant for Healthie GraphQL API",
+  "author": {
+    "name": "Healthie"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/healthie/healthie-dev-assist"
+  },
+  "homepage": "https://www.gethealthie.com/",
+  "documentation": "https://github.com/healthie/healthie-dev-assist",
+  "support": "https://github.com/healthie/healthie-dev-assist/issues",
+  "keywords": ["api", "productivity"],
+  "server": {
+    "type": "node",
+    "entry_point": "setup.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/setup.js"],
+      "env": {
+        "HEALTHIE_API_KEY": "${api_key}"
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "execute",
+      "description": "Execute a GraphQL operation against Healthie's API"
+    },
+    {
+      "name": "introspect",
+      "description": "Get detailed information about types from the GraphQL schema"
+    },
+    {
+      "name": "search_schema",
+      "description": "Search the GraphQL schema for types, fields, queries, or mutations"
+    }
+  ],
+  "user_config": {
+    "api_key": {
+      "type": "string",
+      "title": "API Key",
+      "description": "Your API key for authentication",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=14.0.0"
+    }
+  },
+  "license": ""
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Development assistant for Healthie GraphQL API",
   "scripts": {
     "start": "node setup.js",
+    "pack": "npx @anthropic-ai/dxt pack",
     "regenerate-schema": "node regenerate-schema.js",
     "postinstall": "echo '✓ Dependencies installed. Run npm run setup to start the MCP server.'"
   },


### PR DESCRIPTION
This PR adds DXT (Desktop Extension) packaging support to enable distribution through Anthropic's
upcoming extension directory and provide an improved installation experience in Claude Desktop.

## Background

Anthropic is building a directory to make finding MCP server extensions simpler, with DXT bundling
as a requirement. Packaging the MCP server as a DXT bundle also provides a streamlined user
interface in Claude Desktop during installation, making it easier for users to discover and set up
the Healthie API assistant.

**Related links:**
- [DXT Repository](https://github.com/anthropics/dxt)
- [Desktop Extensions Announcement](https://www.anthropic.com/engineering/desktop-extensions)

## Testing

To test the DXT packaging:
```bash
npm run pack
```

This will generate a .dxt bundle that can be installed in Claude Desktop or distributed through
Anthropic's extension directory.