### PR TITLE
Add optional AuthorizationShard header support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ HEALTHIE_API_KEY=your_api_key_here
 # Environment: staging only (production is not supported — see README)
 # HEALTHIE_ENV=staging
 
+# Optional: shard authorization ID (only needed if your data is in a shard environment)
+# HEALTHIE_AUTHORIZATION_SHARD=your_shard_id_here
+
 # Optional: path to environments.json for multi-env support
 # ENVIRONMENTS_FILE=./environments.json

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ HEALTHIE_API_KEY=your-api-key-here
 
 > Schema search and introspection work without a key. `query` and `mutate` require one.
 
+**Shard environments:** If your data is hosted in a Healthie shard environment, also set:
+```
+HEALTHIE_AUTHORIZATION_SHARD=your-shard-id
+```
+
 ### 3. Download the schema
 
 ```bash
@@ -198,7 +203,8 @@ Edit `environments.json`:
 {
   "staging": {
     "apiUrl": "https://staging-api.gethealthie.com/graphql",
-    "apiKey": "your-staging-key"
+    "apiKey": "your-staging-key",
+    "authorizationShard": "optional-shard-id"
   }
 }
 ```

--- a/config.ts
+++ b/config.ts
@@ -13,6 +13,8 @@ export interface EnvConfig {
   apiKey: string;
   schemaPath: string;
   envName: string;
+  /** Shard authorization ID — required only if your data is in a shard environment */
+  authorizationShard?: string;
 }
 
 const API_URLS: Record<string, string> = {
@@ -38,6 +40,7 @@ function loadConfig(): EnvConfig {
         apiKey: envEntry.apiKey,
         schemaPath,
         envName,
+        authorizationShard: envEntry.authorizationShard || undefined,
       };
     }
   }
@@ -46,6 +49,7 @@ function loadConfig(): EnvConfig {
   // API key is optional — schema search/introspect work without it.
   // query() and mutate() will throw at call time if the key is missing.
   const apiKey = process.env.HEALTHIE_API_KEY ?? "";
+  const authorizationShard = process.env.HEALTHIE_AUTHORIZATION_SHARD || undefined;
 
   const apiUrl = API_URLS[envName];
   if (!apiUrl) {
@@ -54,7 +58,7 @@ function loadConfig(): EnvConfig {
     );
   }
 
-  return { apiUrl, apiKey, schemaPath, envName };
+  return { apiUrl, apiKey, schemaPath, envName, authorizationShard };
 }
 
 export const config = loadConfig();

--- a/environments.example.json
+++ b/environments.example.json
@@ -1,6 +1,7 @@
 {
   "staging": {
     "apiUrl": "https://staging-api.gethealthie.com/graphql",
-    "apiKey": "YOUR_STAGING_API_KEY"
+    "apiKey": "YOUR_STAGING_API_KEY",
+    "authorizationShard": "YOUR_SHARD_ID_IF_NEEDED"
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -323,13 +323,18 @@ async function executeGraphQL<T>(
 
   const body = JSON.stringify({ query: operation, variables });
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Basic ${config.apiKey}`,
+    AuthorizationSource: "API",
+  };
+  if (config.authorizationShard) {
+    headers["AuthorizationShard"] = config.authorizationShard;
+  }
+
   const response = await fetch(config.apiUrl, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Basic ${config.apiKey}`,
-      AuthorizationSource: "API",
-    },
+    headers,
     body,
   });
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -77,12 +77,17 @@ export function invalidateCache(): void {
 export async function regenerateSchema(): Promise<{ lines: number; path: string }> {
   const introspectionQuery = getIntrospectionQuery();
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Basic ${config.apiKey}`,
+  };
+  if (config.authorizationShard) {
+    headers["AuthorizationShard"] = config.authorizationShard;
+  }
+
   const response = await fetch(config.apiUrl, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Basic ${config.apiKey}`,
-    },
+    headers,
     body: JSON.stringify({ query: introspectionQuery }),
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -235,7 +235,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
 async function main() {
   // Remove sensitive env vars after config loads — limits sandbox escape blast radius.
   // config.ts already captured everything it needs.
-  const sensitiveKeys = ["HEALTHIE_API_KEY", "ENVIRONMENTS_FILE"];
+  const sensitiveKeys = ["HEALTHIE_API_KEY", "HEALTHIE_AUTHORIZATION_SHARD", "ENVIRONMENTS_FILE"];
   sensitiveKeys.forEach(k => delete process.env[k]);
 
   await ensureSchema();


### PR DESCRIPTION
## Summary
- Adds support for the optional `AuthorizationShard` request header for customers whose data is hosted in a Healthie shard environment
- Configurable via `HEALTHIE_AUTHORIZATION_SHARD` env var or `authorizationShard` field in `environments.json`
- Header is only sent when a value is configured — no impact on non-shard users
- Shard env var is cleaned from `process.env` after config load (matching existing security pattern)

Reference: https://docs.gethealthie.com/guides/api-concepts/authentication/#request-headers

## Files changed
- `config.ts` — added `authorizationShard?` to `EnvConfig`, loaded from both config sources
- `src/api.ts` — conditionally includes `AuthorizationShard` in GraphQL execution requests
- `src/schema.ts` — conditionally includes `AuthorizationShard` in schema introspection requests
- `src/server.ts` — added to sensitive env var cleanup list
- `.env.example`, `environments.example.json`, `README.md` — documented the new option

## Test plan
- [x] `npm run build` compiles cleanly
- [x] Existing tests pass (`npm test`) — shard is optional, so `undefined` works fine
- [x] With `HEALTHIE_AUTHORIZATION_SHARD` set, header appears in outgoing requests
- [x] Without it set, behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)