### PR TITLE
Cancel in-flight GraphQL requests when sandbox exits

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -313,7 +313,8 @@ export async function getSchema(): Promise<string> {
 
 async function executeGraphQL<T>(
   operation: string,
-  variables?: Record<string, unknown>
+  variables?: Record<string, unknown>,
+  signal?: AbortSignal
 ): Promise<T> {
   if (!config.apiKey) {
     throw new Error(
@@ -336,6 +337,7 @@ async function executeGraphQL<T>(
     method: "POST",
     headers,
     body,
+    signal,
   });
 
   if (!response.ok) {
@@ -372,10 +374,16 @@ export async function mutate<T = unknown>(
 
 // ── Healthie API object (injected into sandbox) ───────────────────────────────
 
-export const healthieApi = {
-  search,
-  introspect,
-  schema: getSchema,
-  query,
-  mutate,
-};
+export function createHealthieApi(signal?: AbortSignal) {
+  return {
+    search,
+    introspect,
+    schema: getSchema,
+    query: <T = unknown>(graphql: string, variables?: Record<string, unknown>) =>
+      executeGraphQL<T>(graphql, variables, signal),
+    mutate: <T = unknown>(graphql: string, variables?: Record<string, unknown>) =>
+      executeGraphQL<T>(graphql, variables, signal),
+  };
+}
+
+export const healthieApi = createHealthieApi();

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -1,5 +1,5 @@
 import vm from "vm";
-import { healthieApi } from "./api.js";
+import { createHealthieApi } from "./api.js";
 
 const TIMEOUT_MS = 30_000;
 
@@ -23,9 +23,10 @@ export interface SandboxResult {
  */
 export async function executeInSandbox(code: string): Promise<SandboxResult> {
   const logs: string[] = [];
+  const controller = new AbortController();
 
   const sandbox = {
-    healthie: healthieApi,
+    healthie: createHealthieApi(controller.signal),
     console: {
       log: (...args: unknown[]) => logs.push(args.map(stringify).join(" ")),
       error: (...args: unknown[]) =>
@@ -70,6 +71,8 @@ export async function executeInSandbox(code: string): Promise<SandboxResult> {
 })()
 `.trim();
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
   try {
     const script = new vm.Script(wrapped, {
       filename: "execute_healthie_code",
@@ -83,9 +86,12 @@ export async function executeInSandbox(code: string): Promise<SandboxResult> {
 
     const result = await Promise.race([
       resultPromise,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Execution timed out after 30s")), TIMEOUT_MS)
-      ),
+      new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          controller.abort();
+          reject(new Error("Execution timed out after 30s"));
+        }, TIMEOUT_MS);
+      }),
     ]);
 
     return {
@@ -98,6 +104,9 @@ export async function executeInSandbox(code: string): Promise<SandboxResult> {
       success: false,
       error: logs.length > 0 ? `${message}\n\nConsole output:\n${logs.join("\n")}` : message,
     };
+  } finally {
+    clearTimeout(timeoutHandle);
+    controller.abort();
   }
 }
 

--- a/test/functional.ts
+++ b/test/functional.ts
@@ -228,6 +228,60 @@ await test("Missing API key gives clear error on query/mutate", async () => {
   }
 });
 
+// AbortController — signal threading and cleanup
+console.log("\nAbortController: signal threading and cleanup:");
+
+await test("Abort signal is passed to fetch and aborted after sandbox completes", async () => {
+  const capturedSignals: AbortSignal[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (_url: unknown, init?: { signal?: AbortSignal }) => {
+    if (init?.signal) capturedSignals.push(init.signal);
+    return new Response(JSON.stringify({ data: {} }), { status: 200 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    const result = await executeInSandbox(`
+      healthie.query("{ __typename }");
+      return "done";
+    `);
+
+    assert(result.success, `Sandbox unexpectedly failed: ${result.error}`);
+    assert(capturedSignals.length > 0, "Expected fetch to be called with a signal");
+    assert(
+      capturedSignals.every((s) => s.aborted),
+      "All fetch signals should be aborted after sandbox exits"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+await test("Abort signal is aborted even when sandbox throws", async () => {
+  const capturedSignals: AbortSignal[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (_url: unknown, init?: { signal?: AbortSignal }) => {
+    if (init?.signal) capturedSignals.push(init.signal);
+    return new Response(JSON.stringify({ data: {} }), { status: 200 });
+  }) as typeof globalThis.fetch;
+
+  try {
+    await executeInSandbox(`
+      healthie.query("{ __typename }");
+      throw new Error("intentional");
+    `);
+
+    assert(capturedSignals.length > 0, "Expected fetch to be called with a signal");
+    assert(
+      capturedSignals.every((s) => s.aborted),
+      "All fetch signals should be aborted even after sandbox error"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 // ── Summary ───────────────────────────────────────────────────────────────────
 
 console.log("\n" + "─".repeat(50));


### PR DESCRIPTION
## Summary

- Adds a per-execution `AbortController` to `executeInSandbox`; its signal is threaded into every `healthie.query()` / `healthie.mutate()` fetch call via a new `createHealthieApi(signal)` factory
- `controller.abort()` fires in a `finally` block, so it triggers on both normal completion and timeout — preventing detached async workers from making authenticated API calls after the sandbox has returned
- Adds two tests to `test/functional.ts` that mock global `fetch`, verify the signal is captured, and assert it is aborted after sandbox exit

Closes CHAI-501 — https://linear.app/healthie/issue/CHAI-501/dev-assist-demo-violating-all-operations-run-in-one-execution

## Test plan

- [ ] `npm test` passes (20/20, including 2 new AbortController tests)
- [ ] Confirm a detached `healthie.query()` call inside sandbox code no longer produces post-exit network traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)