### PR TITLE
healthie dev assist fixes

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -16,7 +16,8 @@ import { homedir } from "os";
 import { execSync } from "child_process";
 
 const projectRoot = resolve(import.meta.dirname);
-const startScriptPath = resolve(projectRoot, "start-mcp.sh");
+const tsxCliPath = resolve(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const serverEntryPath = resolve(projectRoot, "src", "server.ts");
 
 // ── Locate Claude Desktop config ──────────────────────────────────────────────
 
@@ -119,8 +120,14 @@ migrateApiKey();
 // ── Update MCP config entry ──────────────────────────────────────────────────
 
 const existing = mcpServers["healthie-dev-assist"];
+// GUI hosts (e.g. Claude Desktop) run with a minimal PATH and are blocked by
+// macOS from executing a shell script located under ~/Documents ("Operation
+// not permitted"). Invoke an absolute node binary directly against tsx + the
+// source entry instead — this keeps __dirname at the project root (so .env and
+// schemas/ resolve correctly) and avoids both the PATH and script-exec issues.
 mcpServers["healthie-dev-assist"] = {
-  command: startScriptPath,
+  command: process.execPath,
+  args: [tsxCliPath, serverEntryPath],
 };
 
 // Clean up orphaned "healthie" entry (left behind by early v2 setup)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -71,6 +71,29 @@ export function invalidateCache(): void {
 }
 
 /**
+ * Recursively null out `defaultValue` on every input field and argument in an
+ * introspection result. Works on a deep clone so the input is left untouched.
+ */
+function stripDefaultValues(data: IntrospectionQuery): IntrospectionQuery {
+  const clone = structuredClone(data);
+  for (const type of clone.__schema.types) {
+    const inputFields = (type as { inputFields?: Array<{ defaultValue?: unknown }> }).inputFields;
+    if (Array.isArray(inputFields)) {
+      for (const field of inputFields) field.defaultValue = null;
+    }
+    const fields = (type as { fields?: Array<{ args?: Array<{ defaultValue?: unknown }> }> }).fields;
+    if (Array.isArray(fields)) {
+      for (const field of fields) {
+        if (Array.isArray(field.args)) {
+          for (const arg of field.args) arg.defaultValue = null;
+        }
+      }
+    }
+  }
+  return clone;
+}
+
+/**
  * Fetch the schema from the live Healthie API via introspection and save it to disk.
  * Invalidates the in-memory cache so subsequent calls use the fresh schema.
  */
@@ -110,8 +133,24 @@ export async function regenerateSchema(): Promise<{ lines: number; path: string 
     throw new Error("No data returned from introspection query");
   }
 
-  const schema = buildClientSchema(json.data);
-  const sdl = printSchema(schema);
+  let sdl: string;
+  try {
+    sdl = printSchema(buildClientSchema(json.data));
+  } catch (err) {
+    // graphql-js' printSchema/astFromValue can't serialize some default values
+    // (e.g. an empty-object `{}` default on a custom-scalar input field), which
+    // throws "Cannot convert value to AST". Default values aren't needed for the
+    // schema-as-reference use case, so strip them and retry.
+    if (err instanceof Error && /convert value to AST/.test(err.message)) {
+      const stripped = stripDefaultValues(json.data);
+      sdl = printSchema(buildClientSchema(stripped));
+      console.warn(
+        "Note: dropped some un-serializable input default values while printing the schema."
+      );
+    } else {
+      throw err;
+    }
+  }
 
   ensureSchemaDirExists();
   writeFileSync(config.schemaPath, sdl, "utf-8");

--- a/start-mcp.sh
+++ b/start-mcp.sh
@@ -6,6 +6,12 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENTRY_SCRIPT="$SCRIPT_DIR/src/server.ts"
 
+# GUI apps (e.g. Claude Desktop) launch this script with a minimal PATH that
+# doesn't include version managers like mise. tsx's `#!/usr/bin/env node`
+# shebang then fails to find node. Prepend common tool locations so `node`
+# (and mise's shims) resolve regardless of how we're launched.
+export PATH="${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
 TSX_BIN="$SCRIPT_DIR/node_modules/.bin/tsx"
 [ -x "$TSX_BIN" ] || { echo "Error: tsx not found. Run 'npm install' in $SCRIPT_DIR"; exit 1; }
 [ -f "$ENTRY_SCRIPT" ] || { echo "Error: server.ts not found at $ENTRY_SCRIPT"; exit 1; }


### PR DESCRIPTION
## Summary
Fixes three issues that prevented `healthie-dev-assist` from setting up and running as an MCP server on macOS (Claude Desktop), plus makes the setup more robust across Node version managers.

## Changes

### `src/schema.ts` — fix `regenerate-schema` crash
- `printSchema()` (graphql-js) throws `Cannot convert value to AST: {}` on certain Healthie input-field default values (e.g. empty-object `{}` defaults on custom-scalar inputs).
- Added a try/catch fallback: on that specific error, strip un-serializable default values from the introspection result and re-print. Default values aren't needed for the schema-as-reference use case.

### `setup.ts` — fix "Server disconnected" in Claude Desktop
- Previously registered the MCP server via `start-mcp.sh` under `~/Documents`. macOS blocks hardened GUI apps (Claude Desktop) from executing shell scripts there → `Operation not permitted`.
- Now registers the server as `process.execPath` (absolute node) running `tsx` against `src/server.ts`. Benefits:
  - No shell-script execution (avoids the macOS restriction).
  - Independent of the host's `PATH`.
  - Runs the source directly, so `__dirname` stays at the project root and `.env` / `schemas/` resolve correctly (compiled `dist/` mode resolves these relative to `dist/` and breaks).

### `start-mcp.sh` — PATH hardening
- GUI/MCP hosts launch with a minimal `PATH` lacking version managers (mise/asdf/nvm), so `tsx`'s `node` shebang couldn't resolve.
- Prepend mise shims + common bin locations to `PATH` before exec, so direct invocations still work.

## Notes / requirements
- Requires Node ≥ 20.11 to run `setup.ts` (uses `import.meta.dirname`).

## Test plan
- [ ] `npm install`
- [ ] `npm run setup` completes without errors and writes a `node + tsx` command to `claude_desktop_config.json`
- [ ] `npm run regenerate-schema` succeeds (no `Cannot convert value to AST` error) and writes `schemas/staging.graphql`
- [ ] Fully restart Claude Desktop; server shows connected (no `Operation not permitted` / `Cannot find module` in `~/Library/Logs/Claude/mcp-server-healthie-dev-assist.log`)
- [ ] In a chat, `introspect` / `search_schema` return schema content

## Note on verification / config generation
- `claude_desktop_config.json` is a machine-local file (`~/Library/Application Support/Claude/`) and is **not** part of this repo.
- On my machine, the currently-working Claude Desktop config was set by a **manual edit** to that file while debugging — it was **not** produced by `npm run setup`.
- The `setup.ts` change here makes a *future* `npm run setup` generate that same `node + tsx` config, but this code path has **not yet been verified end-to-end on a clean config**.
- **Recommended before merge:** run `npm run setup` on a fresh config and confirm it writes a `command: <node>` + `args: [tsx, src/server.ts]` entry and that Claude Desktop connects.